### PR TITLE
Use accent colors in elementary OS

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -61,7 +61,7 @@ public class Photostat.Application : Gtk.Application {
 
     private void init_theme () {
 
-        if (window.length () > 0) {
+        if (windows.length () > 0) {
             return;
         }
 

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -60,13 +60,18 @@ public class Photostat.Application : Gtk.Application {
     }
 
     private void init_theme () {
-        if (windows.length () > 0) {
+
+        if (window.length () > 0) {
             return;
         }
 
         Gtk.Settings.get_default ().gtk_application_prefer_dark_theme = true;
         Gtk.Settings.get_default ().set_property ("gtk-icon-theme-name", "elementary");
-        Gtk.Settings.get_default ().set_property ("gtk-theme-name", "io.elementary.stylesheet.blueberry");
+        GLib.Value value = GLib.Value (GLib.Type.STRING);
+        Gtk.Settings.get_default ().get_property ("gtk-theme-name", ref value);
+        if (!value.get_string ().has_prefix ("io.elementary.stylesheet")) {
+            Gtk.Settings.get_default ().set_property ("gtk-theme-name", "io.elementary.stylesheet.blueberry");
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds accent color support for elementary OS, while using the blueberry stylesheet for other OSs